### PR TITLE
feature(create/start-game): users should be able to create nd start game

### DIFF
--- a/app/controllers/start-game.js
+++ b/app/controllers/start-game.js
@@ -1,0 +1,85 @@
+/*
+* Module dependencies.
+*/
+const mongoose = require('mongoose');
+
+const GameRecords = mongoose.model('Records');
+
+/*
+* Find Game Records by Gameid
+*/
+exports.getGameRecords = (req, res) => {
+  const gameID = req.params.id;
+  GameRecords.findOne({
+    gameID
+  }, (err, savedGame) => {
+    if (err) {
+      return res.send(err);
+    }
+    if (!savedGame) {
+      return res.status(400).json({
+        success: false,
+        message: 'Game Record Not Found!!'
+      });
+    }
+    return res.status(200).json(savedGame);
+  });
+};
+/*
+* Store Game Record
+*/
+exports.saveRecords = (req, res) => {
+  const gameID = req.body.gameID,
+    players = req.body.players,
+    completed = req.body.completed,
+    winner = req.body.winner,
+    rounds = req.body.rounds;
+
+  const gameRecord = new GameRecords({
+    gameID,
+    players,
+    completed,
+    rounds,
+    winner
+  });
+
+  gameRecord.save((err, data) => {
+    if (err) {
+      return res.send(err);
+    }
+    return res.status(201).json({
+      success: true,
+      data,
+      message: 'Thanks for starting a game!'
+    });
+  });
+};
+
+/*
+ * Update Game Record
+*/
+exports.updateRecords = (req, res) => {
+  const gameID = req.body.gameID;
+  const completed = req.body.completed;
+  const winner = req.body.winner;
+  const rounds = req.body.rounds;
+
+  GameRecords.update({
+    gameID
+  }, {
+    $set: {
+      completed,
+      rounds,
+      winner
+    }
+  }, (err, data) => {
+    if (err) {
+      return res.send(err);
+    }
+    return res.status(201).json({
+      success: true,
+      message: 'Gamer Record updated',
+      data
+    });
+  });
+};

--- a/app/models/start-game.js
+++ b/app/models/start-game.js
@@ -1,0 +1,19 @@
+
+/**
+ * Module dependencies.
+ */
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+/**
+ * Game Record Schema
+ */
+const RecordSchema = new Schema({
+  gameID: String,
+  players: [],
+  completed: Boolean,
+  rounds: Number,
+  winner: String
+});
+
+module.exports = mongoose.model('Records', RecordSchema);

--- a/config/routes.js
+++ b/config/routes.js
@@ -1,93 +1,98 @@
-var async = require('async');
+const async = require('async');
+const startGame = require('../app/controllers/start-game');
+const users = require('../app/controllers/users');
+const answers = require('../app/controllers/answers');
+const questions = require('../app/controllers/questions');
+const avatars = require('../app/controllers/avatars');
+const index = require('../app/controllers/index');
 
-module.exports = function(app, passport, auth) {
-    //User Routes
-    var users = require('../app/controllers/users');
-    app.get('/signin', users.signin);
-    app.get('/signup', users.signup);
-    app.get('/chooseavatars', users.checkAvatar);
-    app.get('/signout', users.signout);
 
-    //Setting up the users api
-    app.post('/users', users.create);
-    app.post('/users/avatars', users.avatars);
+module.exports = (app, passport) => {
+    // User Routes
+  app.get('/signin', users.signin);
+  app.get('/signup', users.signup);
+  app.get('/chooseavatars', users.checkAvatar);
+  app.get('/signout', users.signout);
+
+    // Setting up the users api
+  app.post('/users', users.create);
+  app.post('/users/avatars', users.avatars);
 
     // Donation Routes
-    app.post('/donations', users.addDonation);
+  app.post('/donations', users.addDonation);
 
-    app.post('/users/session', passport.authenticate('local', {
-        failureRedirect: '/signin',
-        failureFlash: 'Invalid email or password.'
-    }), users.session);
+  app.post('/users/session', passport.authenticate('local', {
+    failureRedirect: '/signin',
+    failureFlash: 'Invalid email or password.'
+  }), users.session);
 
-    app.get('/users/me', users.me);
-    app.get('/users/:userId', users.show);
+  app.get('/users/me', users.me);
+  app.get('/users/:userId', users.show);
 
-    //Setting the facebook oauth routes
-    app.get('/auth/facebook', passport.authenticate('facebook', {
-        scope: ['email'],
-        failureRedirect: '/signin'
-    }), users.signin);
+    // Setting the facebook oauth routes
+  app.get('/auth/facebook', passport.authenticate('facebook', {
+    scope: ['email'],
+    failureRedirect: '/signin'
+  }), users.signin);
 
-    app.get('/auth/facebook/callback', passport.authenticate('facebook', {
-        failureRedirect: '/signin'
-    }), users.authCallback);
+  app.get('/auth/facebook/callback', passport.authenticate('facebook', {
+    failureRedirect: '/signin'
+  }), users.authCallback);
 
-    //Setting the github oauth routes
-    app.get('/auth/github', passport.authenticate('github', {
-        failureRedirect: '/signin'
-    }), users.signin);
+    // Setting the github oauth routes
+  app.get('/auth/github', passport.authenticate('github', {
+    failureRedirect: '/signin'
+  }), users.signin);
 
-    app.get('/auth/github/callback', passport.authenticate('github', {
-        failureRedirect: '/signin'
-    }), users.authCallback);
+  app.get('/auth/github/callback', passport.authenticate('github', {
+    failureRedirect: '/signin'
+  }), users.authCallback);
 
-    //Setting the twitter oauth routes
-    app.get('/auth/twitter', passport.authenticate('twitter', {
-        failureRedirect: '/signin'
-    }), users.signin);
+    // Setting the twitter oauth routes
+  app.get('/auth/twitter', passport.authenticate('twitter', {
+    failureRedirect: '/signin'
+  }), users.signin);
 
-    app.get('/auth/twitter/callback', passport.authenticate('twitter', {
-        failureRedirect: '/signin'
-    }), users.authCallback);
+  app.get('/auth/twitter/callback', passport.authenticate('twitter', {
+    failureRedirect: '/signin'
+  }), users.authCallback);
 
-    //Setting the google oauth routes
-    app.get('/auth/google', passport.authenticate('google', {
-        failureRedirect: '/signin',
-        scope: [
-            'https://www.googleapis.com/auth/userinfo.profile',
-            'https://www.googleapis.com/auth/userinfo.email'
-        ]
-    }), users.signin);
+    // Setting the google oauth routes
+  app.get('/auth/google', passport.authenticate('google', {
+    failureRedirect: '/signin',
+    scope: [
+      'https://www.googleapis.com/auth/userinfo.profile',
+      'https://www.googleapis.com/auth/userinfo.email'
+    ]
+  }), users.signin);
 
-    app.get('/auth/google/callback', passport.authenticate('google', {
-        failureRedirect: '/signin'
-    }), users.authCallback);
+  app.get('/auth/google/callback', passport.authenticate('google', {
+    failureRedirect: '/signin'
+  }), users.authCallback);
 
-    //Finish with setting up the userId param
-    app.param('userId', users.user);
+    // Finish with setting up the userId param
+  app.param('userId', users.user);
 
     // Answer Routes
-    var answers = require('../app/controllers/answers');
-    app.get('/answers', answers.all);
-    app.get('/answers/:answerId', answers.show);
+  app.get('/answers', answers.all);
+  app.get('/answers/:answerId', answers.show);
     // Finish with setting up the answerId param
-    app.param('answerId', answers.answer);
+  app.param('answerId', answers.answer);
 
     // Question Routes
-    var questions = require('../app/controllers/questions');
-    app.get('/questions', questions.all);
-    app.get('/questions/:questionId', questions.show);
+  app.get('/questions', questions.all);
+  app.get('/questions/:questionId', questions.show);
     // Finish with setting up the questionId param
-    app.param('questionId', questions.question);
+  app.param('questionId', questions.question);
 
     // Avatar Routes
-    var avatars = require('../app/controllers/avatars');
-    app.get('/avatars', avatars.allJSON);
+  app.get('/avatars', avatars.allJSON);
 
-    //Home route
-    var index = require('../app/controllers/index');
-    app.get('/play', index.play);
-    app.get('/', index.render);
+    // Home route
+  app.get('/play', index.play);
+  app.get('/', index.render);
 
+  app.get('/api/games/:id', startGame.getGameRecords);
+  app.post('/api/games/:id/start', startGame.saveRecords);
+  app.post('/api/games/:id/end', startGame.updateRecords);
 };

--- a/public/js/modal.js
+++ b/public/js/modal.js
@@ -1,0 +1,20 @@
+// Get the modal
+const modal = document.getElementById('myModal');
+
+// Get the <span> element that closes the modal
+const span = document.getElementsByClassName('close')[0];
+
+// Open modal as soon as page opens
+modal.style.display = 'block';
+
+// When the user clicks on <span> (x), close the modal
+span.onclick = () => {
+  modal.style.display = 'none';
+};
+
+// When the user clicks anywhere outside of the modal, close it
+window.onclick = function (event) {
+  if (event.target === modal) {
+    modal.style.display = 'none';
+  }
+};

--- a/public/js/services/game.js
+++ b/public/js/services/game.js
@@ -1,209 +1,257 @@
 angular.module('mean.system')
   .factory('game', ['socket', '$timeout', function (socket, $timeout) {
+    const game = {
+      id: null, // This player's socket ID, so we know who this player is
+      gameID: null,
+      players: [],
+      playerIndex: 0,
+      winningCard: -1,
+      winningCardPlayer: -1,
+      gameWinner: -1,
+      table: [],
+      czar: null,
+      playerMinLimit: 3,
+      playerMaxLimit: 12,
+      pointLimit: null,
+      state: null,
+      round: 0,
+      time: 0,
+      curQuestion: null,
+      notification: null,
+      timeLimits: {},
+      joinOverride: false
+    };
 
-  var game = {
-    id: null, // This player's socket ID, so we know who this player is
-    gameID: null,
-    players: [],
-    playerIndex: 0,
-    winningCard: -1,
-    winningCardPlayer: -1,
-    gameWinner: -1,
-    table: [],
-    czar: null,
-    playerMinLimit: 3,
-    playerMaxLimit: 6,
-    pointLimit: null,
-    state: null,
-    round: 0,
-    time: 0,
-    curQuestion: null,
-    notification: null,
-    timeLimits: {},
-    joinOverride: false
-  };
+    const notificationQueue = [];
+    let timeout = false;
+    const self = this;
+    let joinOverrideTimeout = 0;
 
-  var notificationQueue = [];
-  var timeout = false;
-  var self = this;
-  var joinOverrideTimeout = 0;
-
-  var addToNotificationQueue = function(msg) {
-    notificationQueue.push(msg);
-    if (!timeout) { // Start a cycle if there isn't one
-      setNotification();
-    }
-  };
-  var setNotification = function() {
-    if (notificationQueue.length === 0) { // If notificationQueue is empty, stop
-      clearInterval(timeout);
-      timeout = false;
-      game.notification = '';
-    } else {
-      game.notification = notificationQueue.shift(); // Show a notification and check again in a bit
-      timeout = $timeout(setNotification, 1300);
-    }
-  };
-
-  var timeSetViaUpdate = false;
-  var decrementTime = function() {
-    if (game.time > 0 && !timeSetViaUpdate) {
-      game.time--;
-    } else {
-      timeSetViaUpdate = false;
-    }
-    $timeout(decrementTime, 950);
-  };
-
-  socket.on('id', function(data) {
-    game.id = data.id;
-  });
-
-  socket.on('prepareGame', function(data) {
-    game.playerMinLimit = data.playerMinLimit;
-    game.playerMaxLimit = data.playerMaxLimit;
-    game.pointLimit = data.pointLimit;
-    game.timeLimits = data.timeLimits;
-  });
-
-  socket.on('gameUpdate', function(data) {
-
-    // Update gameID field only if it changed.
-    // That way, we don't trigger the $scope.$watch too often
-    if (game.gameID !== data.gameID) {
-      game.gameID = data.gameID;
-    }
-
-    game.joinOverride = false;
-    clearTimeout(game.joinOverrideTimeout);
-
-    var i;
-    // Cache the index of the player in the players array
-    for (i = 0; i < data.players.length; i++) {
-      if (game.id === data.players[i].socketID) {
-        game.playerIndex = i;
-      }
-    }
-
-    var newState = (data.state !== game.state);
-
-    //Handle updating game.time
-    if (data.round !== game.round && data.state !== 'awaiting players' &&
-      data.state !=='game ended' && data.state !== 'game dissolved') {
-      game.time = game.timeLimits.stateChoosing - 1;
-      timeSetViaUpdate = true;
-    } else if (newState && data.state === 'waiting for czar to decide') {
-      game.time = game.timeLimits.stateJudging - 1;
-      timeSetViaUpdate = true;
-    } else if (newState && data.state === 'winner has been chosen') {
-      game.time = game.timeLimits.stateResults - 1;
-      timeSetViaUpdate = true;
-    }
-
-    // Set these properties on each update
-    game.round = data.round;
-    game.winningCard = data.winningCard;
-    game.winningCardPlayer = data.winningCardPlayer;
-    game.winnerAutopicked = data.winnerAutopicked;
-    game.gameWinner = data.gameWinner;
-    game.pointLimit = data.pointLimit;
-
-    // Handle updating game.table
-    if (data.table.length === 0) {
-      game.table = [];
-    } else {
-      var added = _.difference(_.pluck(data.table,'player'), _.pluck(game.table,'player'));
-      var removed = _.difference(_.pluck(game.table,'player'), _.pluck(data.table,'player'));
-      for (i = 0; i < added.length; i++) {
-        for (var j = 0; j < data.table.length; j++) {
-          if (added[i] === data.table[j].player) {
-            game.table.push(data.table[j],1);
-          }
-        }
-      }
-      for (i = 0; i < removed.length; i++) {
-        for (var k = 0; k < game.table.length; k++) {
-          if (removed[i] === game.table[k].player) {
-            game.table.splice(k,1);
-          }
-        }
-      }
-    }
-
-    if (game.state !== 'waiting for players to pick' || game.players.length !== data.players.length) {
-      game.players = data.players;
-    }
-
-    if (newState || game.curQuestion !== data.curQuestion) {
-      game.state = data.state;
-    }
-
-    if (data.state === 'waiting for players to pick') {
-      game.czar = data.czar;
-      game.curQuestion = data.curQuestion;
-      // Extending the underscore within the question
-      game.curQuestion.text = data.curQuestion.text.replace(/_/g,'<u></u>');
-
-      // Set notifications only when entering state
-      if (newState) {
-        if (game.czar === game.playerIndex) {
-          addToNotificationQueue('You\'re the Card Czar! Please wait!');
-        } else if (game.curQuestion.numAnswers === 1) {
-          addToNotificationQueue('Select an answer!');
-        } else {
-          addToNotificationQueue('Select TWO answers!');
-        }
-      }
-    } else if (data.state === 'waiting for czar to decide') {
-      if (game.czar === game.playerIndex) {
-        addToNotificationQueue("Everyone's done. Choose the winner!");
+    var setNotification = function () {
+      // If notificationQueue is empty, stop
+      if (notificationQueue.length === 0) {
+        clearInterval(timeout);
+        timeout = false;
+        game.notification = '';
       } else {
-        addToNotificationQueue("The czar is contemplating...");
+        // Show a notification and check again in a bit
+        game.notification = notificationQueue.shift();
+        timeout = $timeout(setNotification, 1300);
       }
-    } else if (data.state === 'winner has been chosen' &&
-              game.curQuestion.text.indexOf('<u></u>') > -1) {
-      game.curQuestion = data.curQuestion;
-    } else if (data.state === 'awaiting players') {
-      joinOverrideTimeout = $timeout(function() {
-        game.joinOverride = true;
-      }, 15000);
-    } else if (data.state === 'game dissolved' || data.state === 'game ended') {
-      game.players[game.playerIndex].hand = [];
+    };
+
+    const addToNotificationQueue = function (msg) {
+      notificationQueue.push(msg);
+      if (!timeout) { // Start a cycle if there isn't one
+        setNotification();
+      }
+    };
+
+
+    let timeSetViaUpdate = false;
+    var decrementTime = function () {
+      if (game.time > 0 && !timeSetViaUpdate) {
+        game.time--;
+      } else {
+        timeSetViaUpdate = false;
+      }
+      $timeout(decrementTime, 950);
+    };
+
+    socket.on('id', (data) => {
+      game.id = data.id;
+    });
+
+    socket.on('prepareGame', (data) => {
+      game.playerMinLimit = data.playerMinLimit;
+      game.playerMaxLimit = data.playerMaxLimit;
+      game.pointLimit = data.pointLimit;
+      game.timeLimits = data.timeLimits;
+    });
+
+    socket.on('gameUpdate', (data) => {
+      // Update gameID field only if it changed.
+      // That way, we don't trigger the $scope.$watch too often
+      if (game.gameID !== data.gameID) {
+        game.gameID = data.gameID;
+      }
+
+      game.joinOverride = false;
+      clearTimeout(game.joinOverrideTimeout);
+
+      let i;
+      // Cache the index of the player in the players array
+      for (i = 0; i < data.players.length; i++) {
+        if (game.id === data.players[i].socketID) {
+          game.playerIndex = i;
+        }
+      }
+
+      const newState = (data.state !== game.state);
+
+      // Handle updating game.time
+      if (data.round !== game.round && data.state !==
+        'awaiting players' &&
+        data.state !== 'game ended' && data.state !==
+        'game dissolved') {
+        game.time = game.timeLimits.stateChoosing - 1;
+        timeSetViaUpdate = true;
+      } else if (newState && data.state === 'waiting for czar to draw cards') {
+        game.time = game.timeLimits.stateDrawCards - 1;
+        timeSetViaUpdate = true;
+      } else if (newState && data.state === 'waiting for czar to decide') {
+        game.time = game.timeLimits.stateJudging - 1;
+        timeSetViaUpdate = true;
+      } else if (newState && data.state === 'winner has been chosen') {
+        game.time = game.timeLimits.stateResults - 1;
+        timeSetViaUpdate = true;
+      }
+
+      // Set these properties on each update
+      game.round = data.round;
+      game.winningCard = data.winningCard;
+      game.winningCardPlayer = data.winningCardPlayer;
+      game.winnerAutopicked = data.winnerAutopicked;
+      game.gameWinner = data.gameWinner;
+      game.pointLimit = data.pointLimit;
+
+      // Handle updating game.table
+      if (data.table.length === 0) {
+        game.table = [];
+      } else {
+        const added = _.difference(_.pluck(data.table, 'player'),
+          _.pluck(game.table, 'player'));
+        const removed = _.difference(_.pluck(game.table, 'player'),
+          _.pluck(data.table, 'player'));
+        for (i = 0; i < added.length; i++) {
+          for (let j = 0; j < data.table.length; j++) {
+            if (added[i] === data.table[j].player) {
+              game.table.push(data.table[j], 1);
+            }
+          }
+        }
+        for (i = 0; i < removed.length; i++) {
+          for (let k = 0; k < game.table.length; k++) {
+            if (removed[i] === game.table[k].player) {
+              game.table.splice(k, 1);
+            }
+          }
+        }
+      }
+
+      if (game.state !== 'waiting for players to pick' ||
+        game.players.length !== data.players.length) {
+        game.players = data.players;
+      }
+
+      if (newState || game.curQuestion !== data.curQuestion) {
+        game.state = data.state;
+      }
+
+      if (data.state === 'waiting for players to pick') {
+        game.czar = data.czar;
+        game.curQuestion = data.curQuestion;
+        // Extending the underscore within the question
+        game.curQuestion.text =
+          data.curQuestion.text.replace(/_/g, '<u></u>');
+
+        // Set notifications only when entering state
+        if (newState) {
+          if (game.czar === game.playerIndex) {
+            addToNotificationQueue('You\'re the Card Czar! Please wait!');
+          } else if (game.curQuestion.numAnswers === 1) {
+            addToNotificationQueue('Select an answer!');
+          } else {
+            addToNotificationQueue('Select TWO answers!');
+          }
+        }
+      } else if (data.state === 'waiting for czar to decide') {
+        if (game.czar === game.playerIndex) {
+          addToNotificationQueue('Everyone\'s done. Choose the winner!');
+        } else {
+          addToNotificationQueue('The czar is contemplating...');
+        }
+      } else if (data.state === 'waiting for czar to draw cards') {
+        if (game.czar === game.playerIndex) {
+          addToNotificationQueue('Click to Draw the Cards!');
+        } else {
+          addToNotificationQueue('The czar is drawing the cards...');
+        }
+      } else if (data.state === 'winner has been chosen' &&
+        game.curQuestion.text.indexOf('<u></u>') > -1) {
+        game.curQuestion = data.curQuestion;
+      } else if (data.state === 'awaiting players') {
+        joinOverrideTimeout = $timeout(() => {
+          game.joinOverride = true;
+        }, 15000);
+      } else if (data.state === 'game dissolved' ||
+        data.state === 'game ended') {
+        game.players[game.playerIndex].hand = [];
+        game.time = 0;
+      }
+    });
+
+    socket.on('notification', (data) => {
+      addToNotificationQueue(data.notification);
+    });
+
+    game.joinGame = function (mode, room, createPrivate) {
+      mode = mode || 'joinGame';
+      room = room || '';
+      createPrivate = createPrivate || false;
+      const userID = window.user ? user._id : 'unauthenticated';
+      socket.emit(mode, {
+        userID,
+        room,
+        createPrivate
+      });
+    };
+
+    game.startGame = () => {
+      socket.emit('startGame');
+    };
+
+    game.saveGame = () => {
+      socket.emit('startGame');
+      if (window.user) {
+        $http({
+          method: 'POST',
+          url: `/api/games/${game.gameID}/start`,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          data: {
+            gameID: game.gameID,
+            players: game.players,
+            completed: false,
+            rounds: 0,
+            winner: ''
+          }
+        })
+          .success((res) => {
+            return res;
+          })
+          .error((err) => {
+            return err;
+          });
+      }
+    };
+
+    game.leaveGame = function() {
+      game.players = [];
       game.time = 0;
-    }
-  });
+      socket.emit('leaveGame');
+    };
 
-  socket.on('notification', function(data) {
-    addToNotificationQueue(data.notification);
-  });
+    game.pickCards = function(cards) {
+      socket.emit('pickCards',{cards: cards});
+    };
 
-  game.joinGame = function(mode,room,createPrivate) {
-    mode = mode || 'joinGame';
-    room = room || '';
-    createPrivate = createPrivate || false;
-    var userID = !!window.user ? user._id : 'unauthenticated';
-    socket.emit(mode,{userID: userID, room: room, createPrivate: createPrivate});
-  };
+    game.pickWinning = function(card) {
+      socket.emit('pickWinning',{card: card.id});
+    };
 
-  game.startGame = function() {
-    socket.emit('startGame');
-  };
+    decrementTime();
 
-  game.leaveGame = function() {
-    game.players = [];
-    game.time = 0;
-    socket.emit('leaveGame');
-  };
-
-  game.pickCards = function(cards) {
-    socket.emit('pickCards',{cards: cards});
-  };
-
-  game.pickWinning = function(card) {
-    socket.emit('pickWinning',{card: card.id});
-  };
-
-  decrementTime();
-
-  return game;
-}]);
+    return game;
+  }]);

--- a/public/views/app.html
+++ b/public/views/app.html
@@ -1,20 +1,41 @@
 </script>
-<div id="app-container" ng-controller="GameController">
-  <div id="menu-container">
-    <div id="logo">
-      <span id="first-word">Cards</span>
-      <span id="second-word"> for</span>
-      <span id="third-word">Humanity</span>
+<!-- navbar starts here -->
+<div landing id="main-bod">
+  <!-- Fixed Logo & Menu Bar Start -->
+  <div class="navigationDiv row ">
+    <div class="col-md-3 col-xs-12">
+      <h2 class="text-center logo_head"><a href='./'>Cards For Humanity</a></h2>
     </div>
-    <div id = 'abandon-game-button' ng-click="abandonGame()">
-        Abandon Game
-    </div>
-        <span id="tweet-container">
-      <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://cfh.io" data-text="Cards for Humanity: A Game for Horrible People Desperately Trying to do Good" data-related="CFH_App">Tweet</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-    </span>
+    <div class="col-md-4"></div>
+    <div class="col-md-5 col-xs-12 nav navmenu ">
+      <ul class="app-menu text-center">
+        <li>
+          <a href="https://twitter.com/share" class="share-button-app" data-url="http://cfh.io"
+            data-text="Cards for Humanity: A Game for Horrible People Desperately Trying to do Good"
+            data-related="CFH_App"><img src="img/twitter.png" /></a>
+          <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https'; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = p + '://platform.twitter.com/widgets.js'; fjs.parentNode.insertBefore(js, fjs); } } (document, 'script', 'twitter-wjs');</script>
+</li>
+<li>
+  <a href="#" class="share-button-app" onclick="
+                        window.open(
+                          'https://www.facebook.com/sharer/sharer.php?u='+encodeURIComponent(location.href),
+                          'facebook-share-dialog',
+                          'width=626,height=436');
+                        return false;"> <img src="img/facebook.png" />
+</a>
+</li>
+<li>
+  <div id='abandon-game-button' ng-controller="GameController" class="btn abandon_game_button" ng-click="abandonGame()">
+    Abandon Gaming
   </div>
-  <div id="gameplay-container">
+</li>
+</ul>
+</div>
+</div>
+</div>
+<!-- navbar ends here -->
+<div id="app-container" ng-controller="GameController">
+  <div id="gameplay-container" class="upper_game_top_margin">
     <div id="upper-gameplay-container">
       <div id="menu-timeremaining-container">
         <div id="menu-container">
@@ -31,3 +52,17 @@
     <answers></answers>
   </div>
 </div>
+<div id="app-container" ng-controller="GameController">
+  <!-- The Modal -->
+  <div id="myModal" class="modal-sm">
+    <!-- Modal content -->
+    <div class="modal-content">
+      <div class="modal-head">
+        <span class="close">&times;</span>
+        <h2><span class="header-text">Welcome..</span></h2>
+      </div>
+      <h4><span class="text">You are about starting a new Game Session... A minimum of 3 players is needed to start the game</span></h4>
+    </div>
+  </div>
+</div>
+<script type="text/javascript" src="../js/modal.js"></script>


### PR DESCRIPTION
#### What does this PR do?

This PR allows users to be able to start a new game session after login or signup

#### Description of Task to be completed?

Users should be able to start a new game session after login or signup.
Currently the game throws you into a new gaming screen and starts the game off immediately, which creates a rather confusing experience for the user.
The task was done using Authenticated End Points, Functions and Bootsrap Modals

#### How should this be manually tested?

This can be tested via Postman. (screenshot attached)

####Any background context you want to provide?

N/A

What are the relevant pivotal tracker stories?

Users should be able to create/start a new game #139456323

Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/25608473/23608525/12587be2-026a-11e7-9ba5-cdcb05af1e2f.png)
